### PR TITLE
swagger-uiを導入。講座一覧APIの仕様を記載。# 28

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -21,6 +21,11 @@ paths:
           description: 受講者テーブル主キー
           required: true
           type: int
+        - name: XSRF-TOKEN
+          in: header
+          description: API認証トークン
+          required: true
+          type: string
       responses:
         '200':
           description: 受講講座一覧
@@ -33,7 +38,7 @@ paths:
 components:
   securitySchemes:
         Bearer:
-          type: apiKey
+          type: XSRF-TOKEN
           in: header
           name: Authorization
           description: API認証トークン

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -31,8 +31,25 @@ paths:
                   $ref: '#/components/schemas/Course'
 components:
   schemas:
-    User:
+    Instructor:
       type: "object"
+      required:
+        - "id"
+        - "name"
+        - "email"
+      properties:
+        id:
+          type: "int"
+          description: "講師テーブル主キー"
+          example: 1
+        name:
+          type: "string"
+          description: "講師名"
+          example: "山田 太郎"
+        email:
+          type: "string"
+          description: "メールアドレス"
+          example: "test@example.com"
     Course:
       type: "object"
       required:
@@ -52,12 +69,15 @@ components:
           type: "string"
           description: "講座サムネイル画像ファイルパス"
           example: "/course/xxx.png"
+        instructor:
+          $ref: '#/components/schemas/Instructor'
         attendance:
           $ref: '#/components/schemas/Attendance'
     Attendance:
       type: "object"
       required:
         - "id"
+        - "progress"
       properties:
         id:
           type: "int"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: 受講管理アプリ API
+servers:
+  - url: 'http://localhost:8080/api'
+paths:
+  /v1/courses:
+    get:
+      tags:
+        - course
+      operationId: getCourses
+      summary: "受講講座一覧参照"
+      description: >
+        受講者IDを指定して、受講している講座一覧情報を参照する
+      security: []
+      parameters:
+        - name: id
+          in: query
+          description: 受講者テーブル主キー
+          required: true
+          type: int
+      responses:
+        '200':
+          description: 受講講座一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+components:
+  schemas:
+    User:
+      type: "object"
+    Course:
+      type: "object"
+      required:
+        - "id"
+        - "title"
+        - "image"
+      properties:
+        id:
+          type: "int"
+          description: "講座テーブル主キー"
+          example: 1
+        title:
+          type: "string"
+          description: "講座名"
+          example: "PHP入門講座"
+        image:
+          type: "string"
+          description: "講座サムネイル画像ファイルパス"
+          example: "/course/xxx.png"
+        attendance:
+          $ref: '#/components/schemas/Attendance'
+    Attendance:
+      type: "object"
+      required:
+        - "id"
+      properties:
+        id:
+          type: "int"
+          description: "受講テーブル主キー"
+          example: 1
+        progress:
+          type: "int"
+          description: "進捗率"
+          example: 70

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,7 +13,8 @@ paths:
       summary: "受講講座一覧参照"
       description: >
         受講者IDを指定して、受講している講座一覧情報を参照する
-      security: []
+      security: 
+        - Bearer: []
       parameters:
         - name: id
           in: query
@@ -30,6 +31,12 @@ paths:
                 items:
                   $ref: '#/components/schemas/Course'
 components:
+  securitySchemes:
+        Bearer:
+          type: apiKey
+          in: header
+          name: Authorization
+          description: API認証トークン
   schemas:
     Instructor:
       type: "object"
@@ -56,6 +63,8 @@ components:
         - "id"
         - "title"
         - "image"
+        - "instructor"
+        - "attendance"
       properties:
         id:
           type: "int"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,7 +16,7 @@ paths:
       security: 
         - Bearer: []
       parameters:
-        - name: id
+        - name: student_id
           in: query
           description: 受講者テーブル主キー
           required: true
@@ -41,11 +41,11 @@ components:
     Instructor:
       type: "object"
       required:
-        - "id"
+        - "instructor_id"
         - "name"
         - "email"
       properties:
-        id:
+        instructor_id:
           type: "int"
           description: "講師テーブル主キー"
           example: 1
@@ -60,13 +60,13 @@ components:
     Course:
       type: "object"
       required:
-        - "id"
+        - "course_id"
         - "title"
         - "image"
         - "instructor"
         - "attendance"
       properties:
-        id:
+        course_id:
           type: "int"
           description: "講座テーブル主キー"
           example: 1
@@ -85,10 +85,10 @@ components:
     Attendance:
       type: "object"
       required:
-        - "id"
+        - "attendance_id"
         - "progress"
       properties:
-        id:
+        attendance_id:
           type: "int"
           description: "受講テーブル主キー"
           example: 1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -38,9 +38,9 @@ paths:
 components:
   securitySchemes:
         Bearer:
-          type: XSRF-TOKEN
+          type: apiKey
           in: header
-          name: Authorization
+          name: XSRF-TOKEN
           description: API認証トークン
   schemas:
     Instructor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,12 @@ services:
       - 8088:8080
     depends_on:
       - db
+ swagger-ui:
+    image: swaggerapi/swagger-ui
+    container_name: "swagger-ui"
+    ports:
+      - "8002:8080"
+    volumes:
+      - ./api/openapi.yaml:/openapi.yaml
+    environment:
+      SWAGGER_JSON: /openapi.yaml


### PR DESCRIPTION
## Issue
swagger-uiを導入し、講座一覧参照APIの仕様を記載。
https://gut-familie.atlassian.net/browse/JKA-28

## やったこと
新しくswagger-uiのイメージを導入。
swagger-uiで参照するyamlファイルを作成。

## 確認方法
- dockerを一度再起動し、http://localhost:8002/ で確認する。

## その他共有点
- 設計規約はこちらを参考にしました。https://future-architect.github.io/articles/20200409/