### PR TITLE
#671 Swagger の講師のレッスン更新APIにstatusカラムを追加(ごめ)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1390,6 +1390,10 @@ paths:
                   type: "string"
                   description: 備考
                   example: '備考'
+                status:
+                  type: "string"
+                  description: ステータス
+                  example: 'public'
       responses:
         '200':
           description: "Success"


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-671
## 概要
- Swagger の講師のレッスン更新APIにstatusカラムを追加
## 動作確認手順
- SwaggerUI
/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}}
- body
```
{
  "title": "レッスンタイトル",
  "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
  "remarks": "備考",
  "status": "public"
}
```
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません