### PR TITLE
#683 Swaggerにチャプターの更新・ステータス更新のAPIを追加(ごめ)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2348,6 +2348,46 @@ paths:
                   result:
                     type: "boolean"
                     example: true
+    patch:
+      tags:
+        -  Manager-Chapter
+      operationId: patchManagerCourseChapter
+      summary: "チャプター情報を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                title:
+                  type: "string"
+                  description: タイトル
+                  example: 'チャプタータイトル'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
     delete:
       tags:
         - Manager-Chapter
@@ -2371,6 +2411,47 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/status:
+    patch:
+      tags:
+        -  Manager-Chapter
+      operationId: patchManagerCourseChapterStatus
+      summary: "チャプターの公開状態を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座ID
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターID
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - "status"
+              type: "object"
+              properties:
+                status:
+                  type: "string"
+                  description: 状態(公開、非公開)
+                  example: 'public'
+      responses:
+        200:
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: "object"
                 properties:
                   result:
                     type: "boolean"


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-683
## 概要
- Swaggerにチャプターの更新・ステータス更新のAPIを追加
## 動作確認手順
- PATCHリクエスト
/api/v1/manager/course/{course_id}/chapter/{chapter_id}
/api/v1/manager/course/{course_id}/chapter/{chapter_id}/status
- body
```
{
  "title": "チャプタータイトル"
}
```
```
{
  "status": "public"
}
```
- レスポンス
```
{
  "result": true
}
```
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません