### PR TITLE
#684 Swaggerにマネージャーのレッスンの更新・並び替え・削除のAPIを追加(ごめ)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2456,6 +2456,144 @@ paths:
                   result:
                     type: "boolean"
                     example: true
+  # マネージャー 講座-チャプター-レッスン 
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}}:
+    put:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLesson
+      summary: "レッスン情報を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                title:
+                  type: "string"
+                  description: タイトル
+                  example: 'レッスンタイトル'
+                url:
+                  type: "string"
+                  description: URL
+                  example: 'https://www.youtube.com/watch?v=xxxxxxxxxxx'
+                remarks:
+                  type: "string"
+                  description: 備考
+                  example: '備考'
+                status:
+                  type: "string"
+                  description: ステータス
+                  example: 'public'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+    delete:
+      tags:
+        - Manager-Lesson
+      operationId: deleteManagerChapterLesson
+      summary: "レッスン情報を削除する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/sort:
+    post:
+      tags: 
+        - Manager-Lesson
+      operationId: sortManagerChapterLesson
+      summary: "レッスン情報の並び順を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer 
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                lessons:
+                  type: "array"
+                  description: レッスンの配列
+                  items:
+                    type: "object"
+                    properties:
+                      lesson_id:
+                        $ref: '#/schemas/lesson/LessonId'
+                      order:
+                        $ref: '#/schemas/lesson/Order'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
   # お知らせ
   /api/v1/notification:
     get:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2348,6 +2348,46 @@ paths:
                   result:
                     type: "boolean"
                     example: true
+    patch:
+      tags:
+        -  Manager-Chapter
+      operationId: patchManagerCourseChapter
+      summary: "チャプター情報を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                title:
+                  type: "string"
+                  description: タイトル
+                  example: 'チャプタータイトル'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
     delete:
       tags:
         - Manager-Chapter
@@ -2371,6 +2411,47 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/status:
+    patch:
+      tags:
+        -  Manager-Chapter
+      operationId: patchManagerCourseChapterStatus
+      summary: "チャプターの公開状態を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座ID
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターID
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - "status"
+              type: "object"
+              properties:
+                status:
+                  type: "string"
+                  description: 状態(公開、非公開)
+                  example: 'public'
+      responses:
+        200:
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: "object"
                 properties:
                   result:
                     type: "boolean"


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-684
## 概要
- Swaggerにマネージャーのレッスンの更新・並び替え・削除のAPIを追加
## 動作確認手順
- PATCHリクエスト
/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}}
/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/sort
- body
```
{
  "title": "レッスンタイトル",
  "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
  "remarks": "備考",
  "status": "public"
}
```
```
{
  "lessons": [
    {
      "lesson_id": 1,
      "order": 1
    }
  ]
}
```
- レスポンス
```
{
  "result": true
}
```
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません