### PR TITLE
SwaggerにInstructor/LessonControllerとManager/LessonControllerのAPI記述（はいしま）

### DIFF
--- a/api/bundle-yaml/instructor-lesson.yaml
+++ b/api/bundle-yaml/instructor-lesson.yaml
@@ -148,6 +148,52 @@ paths:
                   result:
                     type: boolean
                     example: true
+  '/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title':
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonTitle
+      summary: レッスン名を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: タイトル
+                  example: レッスンタイトル
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - result
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   '/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/sort':
     post:
       tags:
@@ -182,6 +228,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/LessonId'
                       order:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  '/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status':
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonStatus
+      summary: レッスンの公開状態を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody: null
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - status
+            type: object
+            properties:
+              status:
+                type: string
+                description: 状態(公開、非公開)
+                example: public
       responses:
         '200':
           description: Success

--- a/api/bundle-yaml/manager-lesson.yaml
+++ b/api/bundle-yaml/manager-lesson.yaml
@@ -148,6 +148,52 @@ paths:
                   result:
                     type: boolean
                     example: true
+  '/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title':
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonTitle
+      summary: レッスン名を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: タイトル
+                  example: レッスンタイトル
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - result
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   '/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/sort':
     post:
       tags:
@@ -182,6 +228,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/LessonId'
                       order:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  '/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status':
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonStatus
+      summary: レッスンの公開状態を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody: null
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - status
+            type: object
+            properties:
+              status:
+                type: string
+                description: 状態(公開、非公開)
+                example: public
       responses:
         '200':
           description: Success

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1900,6 +1900,52 @@ paths:
                   result:
                     type: boolean
                     example: true
+  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title:
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonTitle
+      summary: レッスン名を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: タイトル
+                  example: レッスンタイトル
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - result
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/sort:
     post:
       tags:
@@ -1934,6 +1980,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/LessonId'
                       order:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status:
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonStatus
+      summary: レッスンの公開状態を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody: null
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - status
+            type: object
+            properties:
+              status:
+                type: string
+                description: 状態(公開、非公開)
+                example: public
       responses:
         '200':
           description: Success
@@ -3282,6 +3374,52 @@ paths:
                   result:
                     type: boolean
                     example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title:
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonTitle
+      summary: レッスン名を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: タイトル
+                  example: レッスンタイトル
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - result
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/sort:
     post:
       tags:
@@ -3316,6 +3454,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/LessonId'
                       order:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status:
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonStatus
+      summary: レッスンの公開状態を更新する。
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody: null
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - status
+            type: object
+            properties:
+              status:
+                type: string
+                description: 状態(公開、非公開)
+                example: public
       responses:
         '200':
           description: Success

--- a/api/resource/instructor-lesson.yaml
+++ b/api/resource/instructor-lesson.yaml
@@ -148,6 +148,52 @@ paths:
                   result:
                     type: "boolean"
                     example: true
+  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title:
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonTitle
+      summary: "レッスン名を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                title:
+                  type: "string"
+                  description: タイトル
+                  example: 'レッスンタイトル'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
   /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/sort:
     post:
       tags:
@@ -184,6 +230,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
       responses:
         '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status:
+    patch:
+      tags:
+        - Instructor-Lesson
+      operationId: patchInstructorChapterLessonStatus
+      summary: "レッスンの公開状態を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - "status"
+            type: "object"
+            properties:
+              status:
+                type: "string"
+                description: 状態(公開、非公開)
+                example: 'public'
+      responses:
+        200:
           description: "Success"
           content:
             application/json:

--- a/api/resource/manager-lesson.yaml
+++ b/api/resource/manager-lesson.yaml
@@ -148,6 +148,52 @@ paths:
                   result:
                     type: "boolean"
                     example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title:
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonTitle
+      summary: "レッスン名を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: intege
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                title:
+                  type: "string"
+                  description: タイトル
+                  example: 'レッスンタイトル'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                required:
+                  - "result"
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
   /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/sort:
     post:
       tags:
@@ -184,6 +230,52 @@ paths:
                         $ref: '#../components/schemas/Lesson.yml#/Order'
       responses:
         '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  result:
+                    type: "boolean"
+                    example: true
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status:
+    patch:
+      tags:
+        - Manager-Lesson
+      operationId: patchManagerChapterLessonStatus
+      summary: "レッスンの公開状態を更新する。"
+      parameters:
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          type: integer
+        - name: lesson_id
+          in: path
+          description: レッスンテーブルの主キー
+          required: true
+          type: integer
+      requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            required:
+              - "status"
+            type: "object"
+            properties:
+              status:
+                type: "string"
+                description: 状態(公開、非公開)
+                example: 'public'
+      responses:
+        200:
           description: "Success"
           content:
             application/json:

--- a/api/swagger-sample/index.html
+++ b/api/swagger-sample/index.html
@@ -38,7 +38,8 @@
 
       // Build a system
       const ui = SwaggerUIBundle({
-        url: "https://yukihirolaravel.github.io/laravel_next_docker/api/openapi.yaml",
+        // url: "https://yukihirolaravel.github.io/laravel_next_docker/api/openapi.yaml",
+        url: "../openapi.yaml", // ここを変更
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/api/swagger-sample/index.html
+++ b/api/swagger-sample/index.html
@@ -38,8 +38,7 @@
 
       // Build a system
       const ui = SwaggerUIBundle({
-        // url: "https://yukihirolaravel.github.io/laravel_next_docker/api/openapi.yaml",
-        url: "../openapi.yaml", // ここを変更
+        url: "https://yukihirolaravel.github.io/laravel_next_docker/api/openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
## Issue
#JKA-745 SwaggerにInstructor/LessonControllerとManager/LessonControllerの実装済みのAPI記述
https://gut-familie.atlassian.net/browse/JKA-745

## 概要
SwaggerにInstructor/LessonControllerとManager/LessonControllerの実装中のAPI記述

JKA-747 新権限マネージャー設立による配下のinstructorに紐づくレッスン"名"更新API作成
JKA-748 新権限マネージャー設立による配下のinstructorに紐づくレッスン"ステータス"更新API作成
　- instructor-lesson
　- manager-lesson
　
## 動作確認手順
swagger で変更箇所を確認

## 考慮して欲しいこと
実装完了前のタスクのため、
instructor-chapter
 /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/status:　　
  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}:
 を参考に作成しました。