### PR TITLE
お知らせ表示種別を更新するAPIの仕様をswaggerに追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2963,65 +2963,6 @@ paths:
                               type: integer
                               description: ページ総数
                               example: 1
-  /api/v1/instructor/notification/type/{notification_type}:
-    put:
-      tags:
-        - Instructor-Notification
-      operationId: put-instructor-notification-type
-      summary: お知らせ表示種別を更新する。
-      parameters:
-        - in: header
-          name: Origin
-          schema:
-            type: string
-          required: true
-          example: http://localhost:3000
-        - in: header
-          name: Referer
-          schema:
-            type: string
-          required: true
-          example: http://localhost:3000
-        - in: header
-          name: X-XSRF-TOKEN
-          schema:
-            type: string
-          required: true
-          example: eyJpdiI6IjJ2Z0J
-        - name: notification_type
-          in: path
-          description: お知らせ表示種別
-          schema:
-            type: string
-            enum:
-              - always
-              - once
-          required: true
-          example: always
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                notifications:
-                  type: array
-                  items:
-                    type: integer
-                    description: お知らせテーブルの主キー
-                  example: [1, 2]
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: boolean
-                    example: true
   /api/v1/instructor/notification/{notification_id}:
     get:
       tags:
@@ -3164,6 +3105,66 @@ paths:
                   result:
                     type: boolean
                     example: true
+  /api/v1/instructor/notification/type/{notification_type}:
+    put:
+      tags:
+        - Instructor-Notification
+      operationId: put-instructor-notification-type
+      summary: お知らせ表示種別を更新する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: notification_type
+          in: path
+          description: お知らせ表示種別
+          schema:
+            type: string
+            enum:
+              - always
+              - once
+          required: true
+          example: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+
   /api/v1/manager/instructor/{instructor_id}:
     get:
       tags:
@@ -5113,65 +5114,6 @@ paths:
                               type: integer
                               description: ページ総数
                               example: 1
-  /api/v1/manager/notification/type/{notification_type}:
-    put:
-      tags:
-        - Manager-Notification
-      operationId: put-instructor-notification-type
-      summary: お知らせ表示種別を更新する。
-      parameters:
-        - in: header
-          name: Origin
-          schema:
-            type: string
-          required: true
-          example: http://localhost:3000
-        - in: header
-          name: Referer
-          schema:
-            type: string
-          required: true
-          example: http://localhost:3000
-        - in: header
-          name: X-XSRF-TOKEN
-          schema:
-            type: string
-          required: true
-          example: eyJpdiI6IjJ2Z0J
-        - name: notification_type
-          in: path
-          description: お知らせ表示種別
-          schema:
-            type: string
-            enum:
-              - always
-              - once
-          required: true
-          example: always
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                notifications:
-                  type: array
-                  items:
-                    type: integer
-                    description: お知らせテーブルの主キー
-                  example: [1, 2]
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: boolean
-                    example: true
   /api/v1/manager/notification/{notification_id}:
     get:
       tags:
@@ -5212,7 +5154,7 @@ paths:
                         type: integer
                         description: お知らせテーブルの主キー
                         example: 1
-                      couse_id:
+                      course_id:
                         type: integer
                         description: 講座テーブル主キー
                         example: 1
@@ -5242,7 +5184,7 @@ paths:
                         enum: ['once', 'always']
     patch:
       tags:
-        - Instructor-Notification
+        - Manager-Notification
       operationId: patch-instructor-notification
       summary: お知らせ情報を更新する。
       parameters:
@@ -5303,6 +5245,65 @@ paths:
                   type: string
                   description: お知らせタイプ
                   example: once
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/manager/notification/type/{notification_type}:
+    put:
+      tags:
+        - Manager-Notification
+      operationId: put-instructor-notification-type
+      summary: お知らせ表示種別を更新する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: notification_type
+          in: path
+          description: お知らせ表示種別
+          schema:
+            type: string
+            enum:
+              - always
+              - once
+          required: true
+          example: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
       responses:
         '200':
           description: Success

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2963,6 +2963,65 @@ paths:
                               type: integer
                               description: ページ総数
                               example: 1
+  /api/v1/instructor/notification/type/{notification_type}:
+    put:
+      tags:
+        - Instructor-Notification
+      operationId: put-instructor-notification-type
+      summary: お知らせ表示種別を更新する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: notification_type
+          in: path
+          description: お知らせ表示種別
+          schema:
+            type: string
+            enum:
+              - always
+              - once
+          required: true
+          example: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   /api/v1/instructor/notification/{notification_id}:
     get:
       tags:
@@ -5054,6 +5113,65 @@ paths:
                               type: integer
                               description: ページ総数
                               example: 1
+  /api/v1/manager/notification/type/{notification_type}:
+    put:
+      tags:
+        - Manager-Notification
+      operationId: put-instructor-notification-type
+      summary: お知らせ表示種別を更新する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: notification_type
+          in: path
+          description: お知らせ表示種別
+          schema:
+            type: string
+            enum:
+              - always
+              - once
+          required: true
+          example: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   /api/v1/manager/notification/{notification_id}:
     get:
       tags:


### PR DESCRIPTION
## issue
- JKA-1047 「お知らせ一覧-タイプ変更API」の仕様をopenapi.yamlに追加

https://www.dropbox.com/scl/fi/z48nq338j6cjhke7h4lbz/JKA-1047.zip?rlkey=1j7el7jpl5gwesolrr3yrcr7g&dl=0
こちらのとおり対応してます。

## 事後報告事項

operationIdについて、manager側で追加したもの
operationId: put-instructor-notification-type
にしてます
operationIdのところでmanagerの表記に変更してないようなのが
この周辺にあり、なにか意図があってそうしてるのかと思ったので
これもそのままにしてます。

##  他( その1)
slackにて、
```
新しいAPI仕様は、可能な限りで以下のAPIパスの下に記述していただけると嬉しいです。
/api/v1/instructor/notification/{notification_id}
/api/v1/manager/notification/{notification_id}
```
とKouさんが記載してましたが、上記はslack上での書き間違いかと、

前タスクの実装が
/api/v1/instructor/notification/type/{notification_type}
/api/v1/manager/notification/type/{notification_type}
で、その流れで当タスクがあったため、

/api/v1/instructor/notification/type/{notification_type}
/api/v1/manager/notification/type/{notification_type}
を追加する方向性で動いております。


##  他( その2)
一旦は、

```
openapi.yamlの修正は、laravel_next_dockerの直下のgitのリポジトリ
の分のため、feature-php-8.3でプッシュして、mainにマージするための
プルリクを出す方向性かと思いましたので、その方向性で考えて・・・・
```

たのですが

```
あぁ、そうか、この前、MTGで、swaggerの件は、
mainからfeatureきって、
mainにマージするプルリクでよい
言うてたの、思い出したので。
そっちでしたか。
```

のとおり、mainからきったfeatureでmainにマージするプルリクを作成しました。
「feature-php-8.3」は、phpのバージョンの話でDockerfileの話なので、
今回のswaggerの話とは別物で、
Laravel 6環境でしてる人も共通で見るswaggerの変更なので、
mainからきったfeatureでmainにマージするプルリクでよいと思いました。
