### PR TITLE
swaggerに2024_11_25調査分の追加(大川)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3062,8 +3062,72 @@ paths:
                   result:
                     type: boolean
                     example: true
-
-  /api/v1/instructor/student/:
+  /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/status:
+    put:
+      tags:
+        - Instructor-Lesson
+      operationId: put-instructor-course-lesson-status
+      summary: 選択済みのレッスンのステータスを一括で更新する
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          schema:
+            type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  description: 講座ステータス
+                  enum: ['public', 'private']
+                lessons:
+                  type: array
+                  items:
+                    type: integer
+                    description: レッスンテーブルの主キー
+                  example: [1, 2, 3]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/instructor/student:
     post:
       tags:
         - Instructor-Student
@@ -3507,7 +3571,55 @@ paths:
                   result:
                     type: boolean
                     example: true
-
+  /api/v1/instructor/notification:
+    delete:
+      tags:
+        - Instructor-Notification
+      operationId: delete-instructor-notification
+      summary: お知らせを一括で削除する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
   /api/v1/manager/instructor/{instructor_id}:
     get:
       tags:
@@ -4208,6 +4320,52 @@ paths:
                       students_count:
                         type: integer
                         example: 1
+  /api/v1/manager/course/{course_id}/attendance/status/{period}:
+    get:
+      tags:
+        - Manager-Course
+      operationId: get-instructor-course-attendance-status-period
+      summary: 完了済みレッスン数と完了済みチャプター数取得する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          schema:
+            type: integer
+        - name: period
+          in: path
+          description: 期間
+          required: true
+          schema:
+            type: string
+            enum: ['today', 'month']
+      responses:
+        '200':
+          description: 完了済みレッスン数と完了済みチャプター数
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  completed_lessons_count:
+                    type: integer
+                    example: 4
+                  completed_chapters_count:
+                    type: integer
+                    example: 2
   /api/v1/manager/course/{course_id}/attendance/{period}:
     get:
       tags:
@@ -5406,8 +5564,72 @@ paths:
                   result:
                     type: boolean
                     example: true
-
-  /api/v1/manager/student/:
+  /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/status:
+    put:
+      tags:
+        - Manager-Lesson
+      operationId: put-instructor-course-lesson-status
+      summary: 選択済みのレッスンのステータスを一括で更新する
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
+        - name: course_id
+          in: path
+          description: 講座テーブルの主キー
+          required: true
+          schema:
+            type: integer
+        - name: chapter_id
+          in: path
+          description: チャプターテーブルの主キー
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  description: 講座ステータス
+                  enum: ['public', 'private']
+                lessons:
+                  type: array
+                  items:
+                    type: integer
+                    description: レッスンテーブルの主キー
+                  example: [1, 2, 3]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/manager/student:
     post:
       tags:
         - Manager-Student
@@ -5827,6 +6049,55 @@ paths:
               - once
           required: true
           example: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notifications:
+                  type: array
+                  items:
+                    type: integer
+                    description: お知らせテーブルの主キー
+                  example: [1, 2]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+  /api/v1/manager/notification:
+    delete:
+      tags:
+        - Manager-Notification
+      operationId: delete-instructor-notification
+      summary: お知らせを一括で削除する。
+      parameters:
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: true
+          example: http://localhost:3000
+        - in: header
+          name: X-XSRF-TOKEN
+          schema:
+            type: string
+          required: true
+          example: eyJpdiI6IjJ2Z0J
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## issue
- JKA-1063 swaggerに2024_11_25調査分の追加

https://www.dropbox.com/scl/fi/mct869qn7r1chz7dcn4zy/_Part2.txt?rlkey=t2cj8c0ry52at94xr9b3cdyiw&dl=0
の
ざっくり仕様_Part2.txt
で調査した分について

下記の、
その１）で1つ
その２) で2つ
その３）で2つ
の計5個を追加した。

事前に調査したざっくり仕様は、
https://www.dropbox.com/scl/fi/mct869qn7r1chz7dcn4zy/_Part2.txt?rlkey=t2cj8c0ry52at94xr9b3cdyiw&dl=0
の
ざっくり仕様_Part2.txt


その１）
Method: GET, URI: /api/v1/manager/course/{course_id}/attendance/status/this-month
Method: GET, URI: /api/v1/manager/course/{course_id}/attendance/status/today
について、

は、既に追加してある
api/v1/instructor/course/{course_id}/attendance/status/{period}
GET|HEAD  api/v1/instructor/course/{course_id}/attendance/status/{period} .................................................................................... Api\Instructor\AttendanceController@showStatus

にならって

  /api/v1/manager/course/{course_id}/attendance/status/{period}:
    get:
で追加



その２）
Method: PUT, URI: /api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/status
と
Method: PUT, URI: /api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/status
を追加


その３）
Method: DELETE, URI: /api/v1/instructor/notification
と
Method: DELETE, URI: /api/v1/manager/notification
を追加

# 他、uriの末尾の/を削ったものあります。

2024/11/26のMTG時、

yujiさんのQA中に

非GETのもので末尾に/があると

問答無用でpostmanがGETにしてしまってハマっちゃうよの件で、（　過去に、それで、めっちゃ、ハマりましたがな！！ )

「それ、swaggerが間違ってるよね！！」

の該当箇所が２か所ありましたので、直してます

１か所目)
```
  /api/v1/instructor/student/:
    post:
```
を
```
  /api/v1/instructor/student:
    post:
```
に変更した。

２か所目)
```
  /api/v1/manager/student/:
    post:
```
を
```
  /api/v1/manager/student:
    post:
```
に変更した。
